### PR TITLE
Make QR code a bitcoin-uri

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -162,7 +162,8 @@ angular.module('blocktrail.wallet')
         amMoment.changeLocale('en-custom');
     });
 angular.module('blocktrail.wallet').config(
-    function($stateProvider, $urlRouterProvider, $logProvider, $analyticsProvider, $sceDelegateProvider, CONFIG) {
+    function($compileProvider, $stateProvider, $urlRouterProvider, $logProvider, $analyticsProvider, $sceDelegateProvider, CONFIG) {
+        $compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|ftp|mailto|tel|file|bitcoin):/);
         $analyticsProvider.firstPageview(false);
         $logProvider.debugEnabled(CONFIG.DEBUG);
 

--- a/src/js/controllers/ReceiveControllers.js
+++ b/src/js/controllers/ReceiveControllers.js
@@ -110,8 +110,8 @@ angular.module('blocktrail.wallet')
                 $scope.newRequest.qrValue = parseFloat($scope.altCurrency.amount);
             }
 
-            if ($scope.newRequest.btcValue) {
-                $scope.newRequest.bitcoinUri += "?amount=" + parseFloat($scope.newRequest.qrValue).toFixed(8);
+            if (!isNaN($scope.newRequest.qrValue) && $scope.newRequest.qrValue.toFixed(8) !== '0.00000000') {
+                $scope.newRequest.bitcoinUri += "?amount=" + $scope.newRequest.qrValue.toFixed(8);
             }
         };
 
@@ -125,7 +125,6 @@ angular.module('blocktrail.wallet')
 
         //generate the first address
         $scope.newAddress();
-
 
         $scope.$on('new_transactions', function(event, transactions) {
             //show popup (and maybe vibrate?) on new tx

--- a/src/templates/receive/receive.new-address.html
+++ b/src/templates/receive/receive.new-address.html
@@ -19,10 +19,47 @@
                     </span>
                 </div>
             </div>
+
+            <div class="col-md-12 col-sm-12 col-xs-12">
+                <div class="form-group form-group-lg">
+                    <label class="control-label capitalise" for="amount">{{ 'AMOUNT' | translate }}</label>
+                    <div class="input-group input-group-lg">
+                        <input ng-model="newRequest.btcValue" ng-change="setAltCurrency()" type="text" class="form-control" id="amount" name="amount" placeholder="0.00000000" autocomplete="off" type="number" min="0" required />
+
+                        <span class="input-group-addon currency">
+                            <span class="altCurrency">
+                                {{ altCurrency.code | toCurrencySymbol}} {{altCurrency.amount}}
+                            </span>
+                        </span>
+
+                        <span class="input-group-btn">
+                            <div class="btn-group" dropdown>
+                                <button type="button" class="btn btn-alt btn-default btn-lg" dropdown-toggle>
+                                    {{ currencyType }} <span class="caret"></span>
+                                </button>
+                                <ul class="dropdown-menu">
+                                    <li ng-repeat="currency in currencies"><a ng-click="updateCurrentType(currency.code)">{{ currency.code }}</a></li>
+                                </ul>
+                            </div>
+                        </span>
+                    </div>
+                    <span class="help help-block text-danger">
+                        <span class="sentence-case" ng-if="errors.amount">
+                            {{ errors.amount | translate }}
+                        </span>
+                    </span>
+                </div>
+            </div>
+
+
             <div class="col-md-12 col-sm-12 col-xs-12">
                 <div class="qrcode-display-section">
-                    <qr ng-if="newRequest.bitcoinUri" text="newRequest.bitcoinUri" type-number="qrSettings.typeNumber" correction-level="qrSettings.correctionLevel" size="qrSettings.SIZE" input-mode="qrSettings.inputMode" image="qrSettings.image"></qr>
-                    <loading-spinner loading-spinner-size="lg" ng-if="!newRequest.address"></loading-spinner>
+                    <div ng-if="newRequest.bitcoinUri">
+                        <a ng-href="{{ newRequest.bitcoinUri }}">
+                        <qr text="newRequest.bitcoinUri" type-number="qrSettings.typeNumber" correction-level="qrSettings.correctionLevel" size="qrSettings.SIZE" input-mode="qrSettings.inputMode" image="qrSettings.image"></qr>
+                        </a>
+                        <loading-spinner loading-spinner-size="lg" ng-if="!newRequest.address"></loading-spinner>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Previously, bitcoin uri's were generated for QR codes, but never exposed as a link. This PR adds the 'amount' field to the Receive form for it to be included in the url. 

The QR now updates when given a value, and it can now be clicked to open the bitcoin uri handler (or the link can be copied)

Might come back to this and make it obvious users can copy the URI.