### PR TITLE
do not change the url when show the send advanced options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 node_modules/
 appconfig.json
 .appconfig.json

--- a/src/templates/send/send.input-screen.html
+++ b/src/templates/send/send.input-screen.html
@@ -55,7 +55,7 @@
         <div class="row advancedOptions">
             <div class="col-xs-12">
                 <div>
-                    <a ng-href="#" ng-click="showAdvanced = !showAdvanced">
+                    <a href="javascript:" ng-click="showAdvanced = !showAdvanced">
                         <span class="bticon bticon-right-open" ng-if="!showAdvanced"></span>
                         <i class="caret"  ng-if="showAdvanced"></i>
                         <span class="sentence-case">{{ 'ADVANCED_SEND_OPTIONS' | translate }}</span>


### PR DESCRIPTION
When the "show advanced" button clicked on the Send page, the URL will change to `/#`.