### PR TITLE
Convert bech32 to legacy format for Bitcoin Cash sweeper

### DIFF
--- a/src/js/modules/wallet/controllers/sweep-coins-modal/sweep-coins-modal.ctrl.js
+++ b/src/js/modules/wallet/controllers/sweep-coins-modal/sweep-coins-modal.ctrl.js
@@ -8,7 +8,8 @@
                                         $translate, $log, $timeout, trackingService, $q) {
 
         var activeWallet = walletsManagerService.getActiveWallet();
-        $scope.walletData = activeWallet.getReadOnlyWalletData();
+        var walletData = activeWallet.getReadOnlyWalletData();
+        $scope.networkType = walletData.networkType;
 
         trackingService.trackEvent(trackingService.EVENTS.SWEEP.SWEEP_START);
 
@@ -49,7 +50,7 @@
         var options = {
             batchSize: 50,
             accountBatchSize: 5,
-            network: $scope.walletData.networkType,
+            network: walletData.networkType,
             testnet: false
         };
 
@@ -59,6 +60,11 @@
         }
 
         activeWallet.getNewAddress().then(function (address) {
+            // Convert to legacy address format if Bitcoin Cash address
+            if (walletData.networkType === 'BCC' || walletData.networkType === 'tBCC') {
+                address = activeWallet.getSdkWallet().sdk.getLegacyBitcoinCashAddress(address);
+            }
+
             options.recipient = address;
             $scope.working = false;
         });

--- a/src/js/modules/wallet/controllers/sweep-coins-modal/sweep-coins-modal.tpl.html
+++ b/src/js/modules/wallet/controllers/sweep-coins-modal/sweep-coins-modal.tpl.html
@@ -8,7 +8,7 @@
             <h2>{{ 'SWEEP_TITLE' | translate }}</h2>
             <div ng-if="form.step === STEPS.WELCOME">
                 <p>
-                    {{ 'SWEEP_INFO' | translate : { network: CONFIG.NETWORKS[walletData.networkType].NETWORK } }}
+                    {{ 'SWEEP_INFO' | translate : { network: CONFIG.NETWORKS[networkType].NETWORK } }}
                 </p>
                 <div class="row">
                     <div class="col-xs-6">
@@ -37,7 +37,7 @@
             </div>
             <div ng-if="form.step === STEPS.BIP44">
                 <p>
-                    {{ 'SWEEP_INFO' | translate : { network: CONFIG.NETWORKS[walletData.networkType].NETWORK } }}
+                    {{ 'SWEEP_INFO' | translate : { network: CONFIG.NETWORKS[networkType].NETWORK } }}
                 </p>
                 <p class="help-block">
                     {{ 'SWEEP_SUPPORTED' | translate }}: Blockchain.info, Mycelium, Jaxx
@@ -76,7 +76,7 @@
 
             <div ng-if="form.step === STEPS.WIF">
                 <p>
-                    {{ 'SWEEP_INFO' | translate : { network: CONFIG.NETWORKS[walletData.networkType].NETWORK } }}
+                    {{ 'SWEEP_INFO' | translate : { network: CONFIG.NETWORKS[networkType].NETWORK } }}
                 </p>
                 <form class="form">
                     <div class="row">
@@ -112,9 +112,9 @@
             <div ng-if="form.step === STEPS.SWEEP">
 
                  <span translate="SWEEPING_CONFIRM_MSG"
-                       translate-value-amount="{{ displaySweepData.totalValue | satoshiToCoin : walletData.networkType : 8 : false : 'hide' }}"
-                       translate-value-fee="{{ displaySweepData.totalFeePaid | satoshiToCoin : walletData.networkType : 8 : false : 'hide' }}"
-                       translate-value-network="{{ CONFIG.NETWORKS[walletData.networkType].NETWORK }}">
+                       translate-value-amount="{{ displaySweepData.totalValue | satoshiToCoin : networkType : 8 : false : 'hide' }}"
+                       translate-value-fee="{{ displaySweepData.totalFeePaid | satoshiToCoin : networkType : 8 : false : 'hide' }}"
+                       translate-value-network="{{ CONFIG.NETWORKS[networkType].NETWORK }}">
                 </span>
 
                 <form class="form">
@@ -131,10 +131,10 @@
             <div ng-if="form.step === STEPS.PUBLISH">
                 <h4>{{ 'DONE' | translate }}!</h4>
                 <p>
-                    {{ 'SWEEP_COMPLETED' | translate : { ticker: CONFIG.NETWORKS[walletData.networkType].TICKER_LONG } }}
+                    {{ 'SWEEP_COMPLETED' | translate : { ticker: CONFIG.NETWORKS[networkType].TICKER_LONG } }}
                 </p>
                 <p class="help-block">
-                    <a href="{{ CONFIG.NETWORKS[walletData.networkType].EXPLORER_TX_URL }}/{{ sweepData.txId }}" target="_blank">{{ 'TX_INFO_MORE_LINK' | translate }}</a>
+                    <a href="{{ CONFIG.NETWORKS[networkType].EXPLORER_TX_URL }}/{{ sweepData.txId }}" target="_blank">{{ 'TX_INFO_MORE_LINK' | translate }}</a>
                 </p>
 
                 <form class="form">


### PR DESCRIPTION
This would change the address to the old format so the sweeper for anything (mnemonics/privkeys) would work again for Bitcoin Cash