### PR TITLE
Add flag to blocklatest

### DIFF
--- a/src/js/modules/core/services/wallet/wallet.service.js
+++ b/src/js/modules/core/services/wallet/wallet.service.js
@@ -436,7 +436,7 @@
     Wallet.prototype._getBlockHeightFromSdkAndUpdateBlockHeightDoc = function(blockHeightDoc) {
         var self = this;
 
-        return self._$q.when(self._sdkWallet.sdk.blockLatest())
+        return self._$q.when(self._sdkWallet.sdk.blockLatest(true))
             .then(function (result) {
                 blockHeightDoc.height = result.height;
                 return blockHeightDoc;


### PR DESCRIPTION
Goes together with https://github.com/blocktrail/blocktrail-sdk-nodejs/tree/b/block-latest
https://github.com/blocktrail/blocktrail-sdk-nodejs/pull/115

This resolved the blockheight `NaN` bug on `wallet-transaction-info-modal.ctrl.js`