### PR TITLE
Refactor fee fetching, improve error handling

### DIFF
--- a/src/js/modules/wallet/controllers/send/send.ctrl.js
+++ b/src/js/modules/wallet/controllers/send/send.ctrl.js
@@ -409,10 +409,8 @@
                                 var highPriorityFee = minSpendable[blocktrailSDK.Wallet.FEE_STRATEGY_HIGH_PRIORITY];
                                 var minRelayFee = minSpendable[blocktrailSDK.Wallet.FEE_STRATEGY_MIN_RELAY_FEE];
                                 $log.debug("minRelayFee fee MINSPENDABLE: " + minRelayFee);
-                                return _applyFeeResult([lowPriorityFee, optimalFee, highPriorityFee, minRelayFee])
-                                    .then(function () {
-                                        throw e;
-                                    });
+                                _applyFeeResult([lowPriorityFee, optimalFee, highPriorityFee, minRelayFee]);
+                                throw e;
                             });
                     } else if (
                         (e instanceof Error && e.message.indexOf("Wallet balance is too low") !== -1) ||
@@ -425,10 +423,8 @@
                                 var highPriorityFee = maxSpendable[blocktrailSDK.Wallet.FEE_STRATEGY_HIGH_PRIORITY].fee;
                                 var minRelayFee = maxSpendable[blocktrailSDK.Wallet.FEE_STRATEGY_MIN_RELAY_FEE].fee;
                                 $log.debug("minRelayFee fee MAXSPENDABLE: " + minRelayFee);
-                                return _applyFeeResult([lowPriorityFee, optimalFee, highPriorityFee, minRelayFee])
-                                    .then(function () {
-                                        throw e;
-                                    });
+                                _applyFeeResult([lowPriorityFee, optimalFee, highPriorityFee, minRelayFee])
+                                 throw e;
                             });
                     } else {
                         throw e;
@@ -526,6 +522,11 @@
             }
 
             if (parseFloat($scope.sendInput.amount).toFixed(8) === "0.00000000") {
+                $scope.errors.amount = "MSG_INVALID_AMOUNT";
+                isValid = false;
+            }
+
+            if ($scope.sendInput.amount * 1e8 <= blocktrailSDK.DUST) {
                 $scope.errors.amount = "MSG_INVALID_AMOUNT";
                 isValid = false;
             }

--- a/src/js/modules/wallet/controllers/send/send.ctrl.js
+++ b/src/js/modules/wallet/controllers/send/send.ctrl.js
@@ -400,7 +400,6 @@
                     // when we get a fee error we use minspendable or maxspendable fee
                     if (
                         e instanceof blocktrail.WalletFeeError ||
-                        (e instanceof Error && e.message === "Wallet balance too low") ||
                         e instanceof blocktrail.WalletSendError
                     ) {
                         return getMinSpendable(localPay)
@@ -410,9 +409,13 @@
                                 var highPriorityFee = minSpendable[blocktrailSDK.Wallet.FEE_STRATEGY_HIGH_PRIORITY];
                                 var minRelayFee = minSpendable[blocktrailSDK.Wallet.FEE_STRATEGY_MIN_RELAY_FEE];
                                 $log.debug("minRelayFee fee MINSPENDABLE: " + minRelayFee);
-                                return _applyFeeResult([lowPriorityFee, optimalFee, highPriorityFee, minRelayFee]);
+                                return _applyFeeResult([lowPriorityFee, optimalFee, highPriorityFee, minRelayFee])
+                                    .then(function () {
+                                        throw e;
+                                    });
                             });
                     } else if (
+                        (e instanceof Error && e.message.indexOf("Wallet balance is too low") !== -1) ||
                         e.message === "Due to additional transaction fee it's not possible to send selected amount"
                     ) {
                         return getMaxSpendable()
@@ -422,7 +425,10 @@
                                 var highPriorityFee = maxSpendable[blocktrailSDK.Wallet.FEE_STRATEGY_HIGH_PRIORITY].fee;
                                 var minRelayFee = maxSpendable[blocktrailSDK.Wallet.FEE_STRATEGY_MIN_RELAY_FEE].fee;
                                 $log.debug("minRelayFee fee MAXSPENDABLE: " + minRelayFee);
-                                return _applyFeeResult([lowPriorityFee, optimalFee, highPriorityFee, minRelayFee]);
+                                return _applyFeeResult([lowPriorityFee, optimalFee, highPriorityFee, minRelayFee])
+                                    .then(function () {
+                                        throw e;
+                                    });
                             });
                     } else {
                         throw e;


### PR DESCRIPTION
UI changes
* When too low amount is provided, still display fees for sending dust
* When too high amount is provided, still display fees for max spendable amount

Code refactor
* Refactored the 3 very similar function calls in $q.all() to a separate function `_resolveFeeByPriority()`
* Updated error message comparison to match new messages from API