### PR TITLE
Fix WIF private key sweeper tool

### DIFF
--- a/src/js/modules/core/services/sweeper/sweeper.service.js
+++ b/src/js/modules/core/services/sweeper/sweeper.service.js
@@ -280,7 +280,7 @@
 
         function submitDebugInfo() {
             var sdk = sdkService.getSdkByActiveNetwork();
-            return sdk.client.post("/mywallet/sweeper/submit-debug-info", null, debugInfo);
+            return sdk.blocktrailClient.post("/mywallet/sweeper/submit-debug-info", null, debugInfo);
         }
 
         return {


### PR DESCRIPTION
Broke because of a SDK variable renaming