### PR TITLE
remove flatmap, downgrade event-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "gulp-if": "^1.2.5",
     "gulp-jasmine": "^2.4.2",
     "gulp-less": "^3.0.3",
-    "gulp-livereload": "^3.8.0",
+    "gulp-livereload": "^4.0.1",
     "gulp-minify-css": "^0.3.0",
     "gulp-ng-annotate": "~2.0.0",
     "gulp-notify": "^2.2.0",


### PR DESCRIPTION
Upgraded gulp-livereload which removes flatmap dependency and downgrades event-stream to 3.3.4 